### PR TITLE
Fix clickable option to work with 10+ series

### DIFF
--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -30,6 +30,10 @@
 
     Chartist.plugins.legend = function (options) {
 
+        function compareNumbers(a, b) {
+            return a - b;
+        }
+
         options = Chartist.extend({}, defaultOptions, options);
 
         return function legend(chart) {
@@ -117,7 +121,7 @@
                     }
 
                     // Reverse sort the removedSeries to prevent removing the wrong index.
-                    removedSeries.sort().reverse();
+                    removedSeries.sort(compareNumbers).reverse();
 
                     removedSeries.forEach(function (series) {
                         seriesCopy.splice(series, 1);


### PR DESCRIPTION
JavaScript uses lexicographical sorting by default with .sort(). As in, 10 comes before 3. This is not what you want when sorting indexes. Use a function to compare. See here http://stackoverflow.com/a/1063027/4351294